### PR TITLE
forgot to pass the payload body to the sign function

### DIFF
--- a/tagshelf/client_hmac.go
+++ b/tagshelf/client_hmac.go
@@ -99,7 +99,9 @@ func (c *HMACClient) Ping() (r Responder, err error) {
 }
 
 func (c *HMACClient) FileUpload(f *File) (r Responder, err error) {
-	err = c.Sign(constant.EpFileUploadM, constant.EpFileUpload, nil)
+	err = c.Sign(
+		constant.EpFileUploadM, constant.EpFileUpload, f.NewReader(),
+	)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fixes HMAC signature, was not passing the body payload to the sign method.